### PR TITLE
Add support for filtering on Pester tags

### DIFF
--- a/Modules/OperationValidation/OperationValidation.Format.ps1xml
+++ b/Modules/OperationValidation/OperationValidation.Format.ps1xml
@@ -24,7 +24,7 @@
      </TableRowEntries>
     </TableControl>
    </View>
- 
+
   <View>
    <Name>OperationValidation</Name>
    <ViewSelectedBy>
@@ -68,6 +68,17 @@
         </CustomItem>
        </Frame>
 
+       <Text>Tags:     </Text>
+         <Frame>
+           <LeftIndent>4</LeftIndent>
+           <CustomItem>
+             <ExpressionBinding>
+              <PropertyName>Tags</PropertyName>
+             </ExpressionBinding>
+           <NewLine/>
+          </CustomItem>
+         </Frame>
+
        <Text>File:     </Text>
        <Frame>
         <LeftIndent>4</LeftIndent>
@@ -78,7 +89,7 @@
          <NewLine/>
         </CustomItem>
        </Frame>
-       
+
        <Text>FilePath: </Text>
        <Frame>
         <LeftIndent>4</LeftIndent>

--- a/Modules/OperationValidation/OperationValidation.psd1
+++ b/Modules/OperationValidation/OperationValidation.psd1
@@ -49,7 +49,7 @@ Description = 'A set of tools for executing validation of the operation of a sys
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-# RequiredModules = @()
+RequiredModules = @('Pester')
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()
@@ -70,13 +70,13 @@ FormatsToProcess = @("OperationValidation.Format.ps1xml")
 FunctionsToExport = @('Get-OperationValidation','Invoke-OperationValidation')
 
 # Cmdlets to export from this module
-CmdletsToExport = '*'
+# CmdletsToExport = '*'
 
 # Variables to export from this module
-VariablesToExport = '*'
+# VariablesToExport = '*'
 
 # Aliases to export from this module
-AliasesToExport = '*'
+# AliasesToExport = '*'
 
 # DSC resources to export from this module
 # DscResourcesToExport = @()

--- a/Modules/VersionedModule/1.0.0/Diagnostics/Simple/PSGallery.Simple.Tests.ps1
+++ b/Modules/VersionedModule/1.0.0/Diagnostics/Simple/PSGallery.Simple.Tests.ps1
@@ -4,7 +4,7 @@ param(
 )
 
 
-Describe 'Simple Validation of PSGallery' {
+Describe 'Simple Validation of PSGallery' -Tag 'AAABBBCCC' {
     It 'The PowerShell Gallery should be responsive' {
         $request = [System.Net.WebRequest]::Create($WebsiteUrl)
         $response = $Request.GetResponse()

--- a/Modules/VersionedModule/2.0.0/Diagnostics/Simple/PSGallery.Simple.Tests.ps1
+++ b/Modules/VersionedModule/2.0.0/Diagnostics/Simple/PSGallery.Simple.Tests.ps1
@@ -1,4 +1,4 @@
-Describe 'Simple Validation of PSGallery' {
+Describe 'Simple Validation of PSGallery' -Tag 'AAABBBCCC' {
     It 'The PowerShell Gallery should be responsive' {
         $request = [System.Net.WebRequest]::Create('https://www.powershellgallery.com')
         $response = $Request.GetResponse()
@@ -6,9 +6,18 @@ Describe 'Simple Validation of PSGallery' {
     }
 }
 
-Describe 'Simple Validation of Microsoft' {
+Describe 'Simple Validation of Microsoft' -Tag 'AAABBBCCC', 'XXXYYYZZZ' {
     It 'Microsoft should be responsive' {
         $request = [System.Net.WebRequest]::Create('https://www.microsoft.com')
+        $response = $Request.GetResponse()
+        $response.StatusCode | Should be OK
+    }
+}
+
+
+Describe 'Simple Validation of Github' -Tag 'JJJKKKLLL' {
+    It 'GitHub should be responsive' {
+        $request = [System.Net.WebRequest]::Create('https://www.github.com')
         $response = $Request.GetResponse()
         $response.StatusCode | Should be OK
     }


### PR DESCRIPTION
## Description
This PR adds support for specifying Pester tags when searching for or invoking OVF tests via two new parameters (`-Tag` and `-ExcludeTag`) to `Get-OperationValidation` and `Invoke-OperationValidation`. It also addresses some PSScriptAnalyzer rule failures and some minor code cleanup.

## Related Issue
Fixes #10

## Motivation and Context
Since Pester includes the ability to attach tags to `Describe` blocks and filter test execution based on them, that ability is needed in OVF as well.

## How Has This Been Tested?
Associated Pester tests have been created to validate OVF can retrieve tests based on a tag or exclude tests with a tag.

> Since we're using AST to inspect the Pester test script and pull out the `Describe` block name and any `tags`, the Pester script is not actually executed when `Get-OperationValidation` searches for matching tests. Therefore expressions will not work when defining tags.

#### This will work
```powershell
describe 'Service Checks' -Tags 'services' {
    ...
}
```

#### This will **NOT** work
```powershell
$myTag = 'services'
describe 'Service Checks' -Tags $myTag {
    ...
}
```


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/operation-validation-framework/16)
<!-- Reviewable:end -->
