### PR TITLE
Support Path and LiteralPath parameters to module directories

### DIFF
--- a/OperationValidation/Private/Get-ModuleList.ps1
+++ b/OperationValidation/Private/Get-ModuleList.ps1
@@ -1,17 +1,38 @@
 function Get-ModuleList {
+    [cmdletbinding(DefaultParameterSetName = 'Name')]
     param (
+        [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
         [string[]]$Name,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Path')]
+        [string[]]$Path,
 
         [version]$Version
     )
 
-    foreach($p in $env:psmodulepath.split(";"))
+    if ($PSCmdlet.ParameterSetName -eq 'Name')
+    {
+        $pathsToSearch = $env:PSModulePath.Split(';')
+    }
+    elseIf ($PSCmdlet.ParameterSetName -eq 'Path')
+    {
+        $pathsToSearch = $Path
+    }
+
+    foreach($p in $pathsToSearch)
     {
         if ( Test-Path -Path $p )
         {
             foreach($modDir in Get-ChildItem -Path $p -Directory)
             {
-                foreach ($n in $name )
+                Write-Debug "Checking for OVF in [$modDir]"
+
+                if ($PSCmdlet.ParameterSetName -eq 'Path')
+                {
+                    $Name = $modDir.Name
+                }
+
+                foreach ($n in $Name )
                 {
                     if ( $modDir.Name -like $n )
                     {
@@ -67,6 +88,10 @@ function Get-ModuleList {
                     }
                 }
             }
+        }
+        else
+        {
+            Write-Error -Message "Could not access [$p]. Does it exist?"
         }
     }
 }

--- a/Tests/Unit/Get-OperationValidation.tests.ps1
+++ b/Tests/Unit/Get-OperationValidation.tests.ps1
@@ -96,5 +96,14 @@ Describe 'Get-OperationValidation' {
                 $output[$i] | Should match $expected[$i]
             }
         }
+        It 'Can get tests by Path' {
+            $tests = $testModuleDir | Get-OperationValidation
+            $tests.Count | should be 4
+        }
+
+        It 'Can get tests by LiteralPath' {
+            $tests = Get-OperationValidation -LiteralPath $testModuleDir
+            $tests.Count | should be 4
+        }
     }
 }

--- a/Tests/Unit/Invoke-OperationValidation.tests.ps1
+++ b/Tests/Unit/Invoke-OperationValidation.tests.ps1
@@ -20,7 +20,7 @@ Describe 'Invoke-OperationValidation' {
         Remove-Module OperationValidation -Verbose:$false
     }
 
-    Context "Invoke-OperationValidation passes override parameters" {
+    Context "Passes override parameters" {
         $tests = Get-OperationValidation -ModuleName VersionedModule -Version '1.0.0'
 
         It "No override parameters supplied" {
@@ -36,7 +36,7 @@ Describe 'Invoke-OperationValidation' {
         }
     }
 
-    Context "Invoke-OperationValidation runs tests based on tags" {
+    Context "Runs tests based on tags" {
         It "Can run tests with certain tag" {
             $results = Invoke-OperationValidation -Tag 'AAABBBCCC'
             $results[0].Result | Should be 'Passed'
@@ -49,6 +49,18 @@ Describe 'Invoke-OperationValidation' {
 
             $results = Invoke-OperationValidation -Modulename VersionedModule -ExcludeTag 'XXXYYYZZZ'
             $results.Count | Should be 2
+        }
+    }
+
+    Context 'Accepts Path and LiteralPath' {
+        It 'Can run tests by Path' {
+            $results = $testModuleDir | Invoke-OperationValidation
+            $results.Count | should be 4
+        }
+
+        It 'Can run tests by LiteralPath' {
+            $results = Invoke-OperationValidation -LiteralPath $testModuleDir
+            $results.Count | should be 4
         }
     }
 


### PR DESCRIPTION
## Description
Adds `-Path` and `-LiteralPath` parameters to `Get-OperationValidation` and `Invoke-OperationValidation`. These allow OperationValidation to inspect tests in modules without that module needing to be available in `$env:PSModulePath`.

## Related Issue
#19
#20 

## Motivation and Context
There are use cases where your OVF module is not installed in `$env:PSModulePath` yet you still want to use OperationValidation to run your tests.

## How Has This Been Tested?
Added Pester tests to validate new parameters

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/operation-validation-framework/26)
<!-- Reviewable:end -->
