### PR TITLE
PR of pester quiet param fix and usebaicparsing for some pester tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- PR25 Discovery Pester 'Describe' block names when the -Name parameter is used (via @GitAMBS)
+- PR25 - Discover Pester 'Describe' block names when the -Name parameter is used (via @GitAMBS)
+- PR29 - Remove Pester 4.0+ warning by using -Show parameter instead of -Quiet. Add -UseBasicParsing parameter to Invoke-WebRequest in tests (via @larssb)
 
 ## [1.0.1] - 2015-12-05
 

--- a/TestArtifacts/VersionedModule/1.0.0/Diagnostics/Simple/PSGallery.Simple.Tests.ps1
+++ b/TestArtifacts/VersionedModule/1.0.0/Diagnostics/Simple/PSGallery.Simple.Tests.ps1
@@ -5,7 +5,7 @@ param(
 
 Describe 'Simple Validation of PSGallery' -Tag 'AAABBBCCC' {
     It 'The PowerShell Gallery should be responsive' {
-        $response = Invoke-WebRequest -Uri $WebsiteUrl
+        $response = Invoke-WebRequest -Uri $WebsiteUrl -UseBasicParsing
         $response.StatusCode | Should Be $StatusCode
     }
 

--- a/TestArtifacts/VersionedModule/2.0.0/Diagnostics/Simple/PSGallery.Simple.Tests.ps1
+++ b/TestArtifacts/VersionedModule/2.0.0/Diagnostics/Simple/PSGallery.Simple.Tests.ps1
@@ -1,13 +1,13 @@
 Describe 'Simple Validation of PSGallery' -Tag 'AAABBBCCC' {
     It 'The PowerShell Gallery should be responsive' {
-        $response = Invoke-WebRequest -Uri 'https://www.powershellgallery.com'
+        $response = Invoke-WebRequest -Uri 'https://www.powershellgallery.com' -UseBasicParsing
         $response.StatusCode | Should be 200
     }
 }
 
 Describe 'Simple Validation of Microsoft' -Tag 'AAABBBCCC', 'XXXYYYZZZ' {
     It 'Microsoft should be responsive' {
-        $response = Invoke-WebRequest -Uri 'https://www.microsoft.com'
+        $response = Invoke-WebRequest -Uri 'https://www.microsoft.com' -UseBasicParsing
         $response.StatusCode | Should be 200
     }
 }
@@ -15,7 +15,7 @@ Describe 'Simple Validation of Microsoft' -Tag 'AAABBBCCC', 'XXXYYYZZZ' {
 
 Describe 'Simple Validation of Github' -Tag 'JJJKKKLLL' {
     It 'GitHub should be responsive' {
-        $response = Invoke-WebRequest -Uri 'https://www.github.com'
+        $response = Invoke-WebRequest -Uri 'https://www.github.com' -UseBasicParsing
         $response.StatusCode | Should be 200
     }
 }


### PR DESCRIPTION
## Description
Fixed the combination of using the OVF -TestFilePath parameter with invoke-pester -quiet or -show. The code, when using the -TestFilePath parameter did not take into consideration the version of Pester and therefore the warning about -Quiet.

While running the Pester tests. Several tests failed as I was using a user through "Runas" while in a Windows user session that is a non-admin user. The "Runas" user does not have IE configured in its profile and therefore the invoke-webrequest cmdlet fails without the -UseBasicParsing parameter. I added that to several tests to avoid this error. Shouldn't be an issue as it is very simple requests via that is tried with invoke-webrequest. 

## Related Issue
#28 

## Motivation and Context
To get rid of an unnecessary warning. That is already fixed for other parameters in OVF.

## How Has This Been Tested?
* Ran invoke-operationvalidation on actual tests on MacOS and thereby PowerShell core Beta v8.
* Executed all the Pester tests provided in the repo.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. <-- I think the current tests already covers.
- [ X] All new and existing tests passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/operation-validation-framework/29)
<!-- Reviewable:end -->
