### PR TITLE
Add .Trim(';')) to input path

### DIFF
--- a/OperationValidation/Private/Get-ModuleList.ps1
+++ b/OperationValidation/Private/Get-ModuleList.ps1
@@ -12,7 +12,7 @@ function Get-ModuleList {
 
     if ($PSCmdlet.ParameterSetName -eq 'Name')
     {
-        $pathsToSearch = $env:PSModulePath.Split(';')
+        $pathsToSearch = $env:PSModulePath.Trim(';').Split(';')
     }
     elseIf ($PSCmdlet.ParameterSetName -eq 'Path')
     {


### PR DESCRIPTION
This fixes an issue where the PSModulePath starts or ends with a semicolon.  This causes $P in line 24 to be empty and throws an error.  Ideally the input should be checked for being not null.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/operation-validation-framework/32)
<!-- Reviewable:end -->
