### PR TITLE
fixed version check

### DIFF
--- a/OperationValidation/Public/Get-OperationValidation.ps1
+++ b/OperationValidation/Public/Get-OperationValidation.ps1
@@ -220,7 +220,7 @@ function Get-OperationValidation {
 
             # Some OVF modules might not have a manifest (.psd1) file.
             if ($manifestFile) {
-                if ($PSVersionTable.PSVersion -ge 5) {
+                if ($PSVersionTable.PSVersion.Major -ge 5) {
                     $manifest = Import-PowerShellDataFile -Path $manifestFile.FullName
                 } else {
                     $manifest = Parse-Psd1 $manifestFile.FullName


### PR DESCRIPTION
Whenever you use Invoke-OperationValidation, you receive an error that it cannot compare an int to the System.Management.Automation.SemanticVersion type.

In addition, due to this version check failure, the call to Import-PowerShellDataFile never succeeds.

## Description
Since the code is only checking the major version in the check (in this case, 5) -- I simply pull $PSVersionTable.PSVersion.Major, which itself is an int32, which resolves this error.

## Related Issue

## Motivation and Context
I like my stuff to work :)


## How Has This Been Tested?
I have not tested this change, but I assume this is undesirable behavior and it's a relatively simple fix.

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/operation-validation-framework/36)
<!-- Reviewable:end -->
